### PR TITLE
change submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ICPCUDA"]
 	path = ICPCUDA
-	url = git@github.com:ipab-slmc/ICPCUDA.git
+	url = https://github.com:ipab-slmc/ICPCUDA.git


### PR DESCRIPTION
When updating recursively from pronto I'm unable to checkout because of the url. This url works.
